### PR TITLE
feat: Improve Docker configuration - Remove fixed container names and implement nginx conf.d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN unzip /tmp/pb.zip -d /pb/
 # uncomment to copy the local pb_hooks dir into the image
 # COPY ./pb_hooks /pb/pb_hooks
 
-EXPOSE 8080
+EXPOSE 8090
 
 # start PocketBase
-CMD ["/pb/pocketbase", "serve", "--http=0.0.0.0:8080"]
+CMD ["/pb/pocketbase", "serve", "--http=0.0.0.0:8090"]

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ docker-compose up -d
 ```
 
 4. Access PocketBase:
-- Direct access: http://localhost:8091
+- Direct access: http://localhost:8092
 - Via Nginx proxy: http://localhost
 - Admin UI: http://localhost/_/
 
 ## Services
 
 ### PocketBase
-- Port: 8091 (direct access)
+- Port: 8092 (direct access)
 - Data: `./data/pb_data` (local volume)
 - Version: 0.29.3 (configurable in .env)
 
@@ -40,7 +40,7 @@ docker-compose up -d
 ## Architecture
 
 ```
-[Client] → [Nginx:80] → [PocketBase:8080] → [Local Volume:./data/pb_data]
+[Client] → [Nginx:80] → [PocketBase:8090] → [Local Volume:./data/pb_data]
 ```
 
 ## Directory Structure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,20 +5,19 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: pocketbase
     restart: unless-stopped
     ports:
-      - "8091:8080"
+      - "8092:8090"
     volumes:
       - ./data/pb_data:/pb/pb_data
 
   nginx:
     image: nginx:alpine
-    container_name: nginx-proxy
     restart: unless-stopped
     ports:
       - "80:80"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d/:/etc/nginx/conf.d/:ro
     depends_on:
       - pocketbase

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name localhost;
+    client_max_body_size 10M;
+
+    location / {
+        # check http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        proxy_read_timeout 360s;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Use PocketBase's natural default port
+        proxy_pass http://pocketbase:8090;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,20 +1,27 @@
-server {
-    listen 80;
-    server_name localhost;
-    client_max_body_size 10M;
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
 
-    location / {
-        # check http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
-        proxy_set_header Connection '';
-        proxy_http_version 1.1;
-        proxy_read_timeout 360s;
+events {
+    worker_connections 1024;
+}
 
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        # Docker Compose service name resolution
-        proxy_pass http://pocketbase:8080;
-    }
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    
+    access_log /var/log/nginx/access.log main;
+    
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Implements #4 - Docker improvements with flexible container names and proper nginx structure

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the configuration of `PocketBase` and `Nginx` in the `Dockerfile`, `docker-compose.yml`, and `nginx.conf` to change the ports used for access and enhance the Nginx configuration.

### Detailed summary
- Changed `EXPOSE` port from `8080` to `8090` in `Dockerfile`.
- Updated `CMD` to serve `PocketBase` on port `8090`.
- Modified `docker-compose.yml` to map port `8092` to `8090`.
- Updated `nginx.conf` to proxy to `PocketBase` on port `8090`.
- Changed README to reflect new access ports.
- Enhanced `nginx.conf` with additional configuration settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->